### PR TITLE
Typo fix and syntax highlight JSON with comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Note: This project assumes you have a working `EventSource` available. If you ar
 
 ## Configuration
 
-Like the [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource#Syntax), the constructor takes an optional configuration object: `new ReconnectingEventSource(url configuration)`. The configuration object is passed through to the underlying `EventSource` and can optionally include the following configuration:
+Like the [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource#Syntax), the constructor takes an optional configuration object: `new ReconnectingEventSource(url, configuration)`. The configuration object is passed through to the underlying `EventSource` and can optionally include the following configuration:
 
-```
+```json5
 {
     // indicating if CORS should be set to include credentials, default `false`
     withCredentials: false,


### PR DESCRIPTION
Adds a comment between the `url` and `configuration` parameters to `ReconnectingEventSource`.

From [this gist](https://gist.github.com/DamianEdwards/31d2457737304ca73556): you can use either `json5` or just simply boring `js` to get GitHub to colorize JSON with comments. This uses `json5`.