### PR TITLE
Add configuration to specify underlying EventSource class

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Note: This project assumes you have a working `EventSource` available. If you ar
 
 Like the [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource#Syntax), the constructor takes an optional configuration object: `new ReconnectingEventSource(url, configuration)`. The configuration object is passed through to the underlying `EventSource` and can optionally include the following configuration:
 
-```json5
+```
 {
     // indicating if CORS should be set to include credentials, default `false`
     withCredentials: false,
@@ -48,10 +48,15 @@ Like the [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventS
     // the maximum time to wait before attempting to reconnect in ms, default `3000`
     // note: wait time is randomised to prevent all clients from attempting to reconnect simultaneously
     max_retry_time: 3000,
+  
+    // a custom class to replace the original [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource#Syntax) class.
+    eventSourceClass: window.EventSource,
 }
-
 ```
 
+The `eventSourceClass` configuration option allows you to use any replacement class that is compatible with the standard
+EventSource, such as [EventSource/eventsource](https://github.com/EventSource/eventsource), as the underlying EventSource
+for the constructed instance.
 
 ## Building from source
 

--- a/src/reconnecting-eventsource.js
+++ b/src/reconnecting-eventsource.js
@@ -24,6 +24,7 @@ export default class ReconnectingEventSource {
 
     constructor(url, configuration) {
         this._configuration = configuration != null ? Object.assign({}, configuration) : null;
+        this._eventSourceClass = EventSource;
 
         this._eventSource = null;
         this._lastEventId = null;
@@ -44,6 +45,11 @@ export default class ReconnectingEventSource {
                 this.max_retry_time = this._configuration.max_retry_time;
                 delete this._configuration['max_retry_time'];
             }
+
+            if (this._configuration.eventSourceClass) {
+                this._eventSourceClass = this._configuration.eventSourceClass;
+                delete this._configuration['eventSourceClass'];
+            }
         }
 
         this._onevent_wrapped = event => { this._onevent(event); };
@@ -63,7 +69,7 @@ export default class ReconnectingEventSource {
             url += 'lastEventId=' + encodeURIComponent(this._lastEventId);
         }
 
-        this._eventSource = new EventSource(url, this._configuration);
+        this._eventSource = new this._eventSourceClass(url, this._configuration);
 
         this._eventSource.onopen = event => { this._onopen(event); };
         this._eventSource.onerror = event => { this._onerror(event); };


### PR DESCRIPTION
This is a pull request for adding a configuration to the ReconnectingEventSource constructor's configuration parameter that allows the user to specify the underlying EventSource implementation to wrap.

This functionality was originally implemented in the following pull request:
https://github.com/fanout/reconnecting-eventsource/pull/45

Since we already have a configuration object that allows for passing of custom parameters, we can do this by adding to the configuration object rather than adding a new constructor parameter.

