### PR TITLE
Use globalThis instead of window and clarify compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,18 @@ Some errors, such as 502, are probably temporary, and ideally wouldn't cause cli
 ## So this thing reconnects forever. How do I make it stop?
 
 The client has to explicitly stop by calling `es.close()`. If you want to control this from the server, have the server send some kind of close instruction for the client to act on.
+
+## Compatibility
+
+Browsers
+* Chrome / Chrome Android 71 and newer
+* Edge 79 and newer
+* Safari 12.2 and newer
+* Firefox / Firefox Android 65 and newer
+* Firefox Android 65 or newer
+* Opera 58 and newer
+* Opera Android 50 and newer
+
+Server
+* Node.js 12.0 and newer
+* Deno 1.38 and newer

--- a/src/main.browser.ts
+++ b/src/main.browser.ts
@@ -1,5 +1,5 @@
 import ReconnectingEventSource, { EventSourceNotAvailableError } from './reconnecting-eventsource';
-Object.assign(window, {
+Object.assign(globalThis, {
   ReconnectingEventSource,
   EventSourceNotAvailableError,
 });


### PR DESCRIPTION
Addresses #76

This PR uses [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) instead of `window` to add objects to global scope.

This also updates README to specify the browsers that are able to use `globalThis`. According to [caniuse.com](https://caniuse.com/mdn-javascript_builtins_globalthis), this covers about 94% of browsers.
